### PR TITLE
#166: Introducing facets for language and reading level

### DIFF
--- a/src/main/scala/no/gdl/bookapi/controller/OPDSController.scala
+++ b/src/main/scala/no/gdl/bookapi/controller/OPDSController.scala
@@ -104,6 +104,9 @@ trait OPDSController {
         <title>{feed.title}</title>
         <updated>{feed.updated.atStartOfDay(ZoneId.systemDefault()).format(dtf)}</updated>
         <link href={feed.feedDefinition.url} rel="self"/>
+        {feed.facets.map(facet =>
+          <link rel="http://opds-spec.org/facet" href={facet.href} title={facet.title} opds:facetGroup={facet.group} opds:activeFacet={facet.isActive.toString}/>)
+        }
         {feed.content.map(feedEntry =>
           <entry>
             <id>urn:uuid:{feedEntry.book.uuid}</id>

--- a/src/main/scala/no/gdl/bookapi/model/api/Book.scala
+++ b/src/main/scala/no/gdl/bookapi/model/api/Book.scala
@@ -115,14 +115,23 @@ case class FeedDefinition(@(ApiModelProperty@field)(description = "The internal 
                           @(ApiModelProperty@field)(description = "The uuid of the feed") uuid: String)
 
 @ApiModel(description = "Information about an OPDS-Feed")
-case class Feed (feedDefinition: FeedDefinition, title: String, description: Option[String], rel: Option[String], updated: LocalDate, content: Seq[FeedEntry], facets: Seq[Facet])
+case class Feed(@(ApiModelProperty@field)(description = "Definitions of the feed") feedDefinition: FeedDefinition,
+                @(ApiModelProperty@field)(description = "Title of the feed") title: String,
+                @(ApiModelProperty@field)(description = "Description of the feed") description: Option[String],
+                @(ApiModelProperty@field)(description = "rel attribute of each entry's link tag") rel: Option[String],
+                @(ApiModelProperty@field)(description = "When the feed was last updated") updated: LocalDate,
+                @(ApiModelProperty@field)(description = "List of feed entries") content: Seq[FeedEntry],
+                @(ApiModelProperty@field)(description = "List of facets, which contain links to other feeds or variants of the current one") facets: Seq[Facet])
 
-@ApiModel(description = "Information about a facet in an OPDS-feed")
-case class Facet(href: String, title: String, group: String, isActive: Boolean)
+@ApiModel(description = "Information about a facet in an OPDS-feed. A facet links to another feed")
+case class Facet(@(ApiModelProperty@field)(description = "The location of the feed referred to, as a URL") href: String,
+                 @(ApiModelProperty@field)(description = "The title of the other feed") title: String,
+                 @(ApiModelProperty@field)(description = "Which group the facet belongs to") group: String,
+                 @(ApiModelProperty@field)(description = "Indicates if this facet is the current feed. Only 1 facet should be set as active per group") isActive: Boolean)
 
 @ApiModel(description = "Information about an Entry in an OPDS-Feed")
-case class FeedEntry (@(ApiModelProperty@field)(description = "The book associated with this entry") book: Book,
-                      @(ApiModelProperty@field)(description = "The revision of the feed") categories: Seq[FeedCategory] = Seq())
+case class FeedEntry(@(ApiModelProperty@field)(description = "The book associated with this entry") book: Book,
+                     @(ApiModelProperty@field)(description = "The revision of the feed") categories: Seq[FeedCategory] = Seq())
 
 @ApiModel(description = "Information about a feed category in an opds-feed")
 case class FeedCategory(@(ApiModelProperty@field)(description = "The url to the category feed") url: String,

--- a/src/main/scala/no/gdl/bookapi/model/api/Book.scala
+++ b/src/main/scala/no/gdl/bookapi/model/api/Book.scala
@@ -115,7 +115,10 @@ case class FeedDefinition(@(ApiModelProperty@field)(description = "The internal 
                           @(ApiModelProperty@field)(description = "The uuid of the feed") uuid: String)
 
 @ApiModel(description = "Information about an OPDS-Feed")
-case class Feed (feedDefinition: FeedDefinition, title: String, description: Option[String], rel: Option[String], updated: LocalDate, content: Seq[FeedEntry])
+case class Feed (feedDefinition: FeedDefinition, title: String, description: Option[String], rel: Option[String], updated: LocalDate, content: Seq[FeedEntry], facets: Seq[Facet])
+
+@ApiModel(description = "Information about a facet in an OPDS-feed")
+case class Facet(href: String, title: String, group: String, isActive: Boolean)
 
 @ApiModel(description = "Information about an Entry in an OPDS-Feed")
 case class FeedEntry (@(ApiModelProperty@field)(description = "The book associated with this entry") book: Book,

--- a/src/main/scala/no/gdl/bookapi/service/FeedService.scala
+++ b/src/main/scala/no/gdl/bookapi/service/FeedService.scala
@@ -55,13 +55,13 @@ trait FeedService {
     }
 
     def facetsForLanguages(currentLanguage: LanguageTag): Seq[Facet] = {
-      readService.listAvailableLanguages.map(lang => Facet(
+      readService.listAvailableLanguagesAsLanguageTags.map(lang => Facet(
         href = s"${
           BookApiProperties.CloudFrontOpds}${BookApiProperties.OpdsNewUrl.url
-          .replace(BookApiProperties.OpdsLanguageParam, lang.code)}",
-        title = s"${lang.name}",
+          .replace(BookApiProperties.OpdsLanguageParam, lang.toString)}",
+        title = s"${lang.displayName}",
         group = "Languages",
-        isActive = LanguageTag(lang.code) == currentLanguage))
+        isActive = lang == currentLanguage))
     }
 
     def facetsForReadingLevels(currentLanguage: LanguageTag, url: String): Seq[Facet] = {

--- a/src/main/scala/no/gdl/bookapi/service/FeedService.scala
+++ b/src/main/scala/no/gdl/bookapi/service/FeedService.scala
@@ -16,7 +16,7 @@ import io.digitallibrary.language.model.LanguageTag
 import no.gdl.bookapi.BookApiProperties
 import no.gdl.bookapi.BookApiProperties.{OpdsLanguageParam, OpdsLevelParam}
 import no.gdl.bookapi.model._
-import no.gdl.bookapi.model.api.{FeedCategory, FeedEntry}
+import no.gdl.bookapi.model.api.{Facet, FeedCategory, FeedEntry}
 import no.gdl.bookapi.model.domain.Sort
 import no.gdl.bookapi.repository.{FeedRepository, TranslationRepository}
 
@@ -36,6 +36,8 @@ trait FeedService {
         case None => books.sortBy(_.book.dateArrived).reverse.headOption.map(_.book.dateArrived).getOrElse(LocalDate.now())
       }
 
+      val facets = facetsForLanguages(language) ++ facetsForReadingLevels(language, url)
+
       feedRepository.forUrl(url.replace(BookApiProperties.OpdsPath,"")).map(feedDefinition => {
         api.Feed(
           api.FeedDefinition(
@@ -47,8 +49,32 @@ trait FeedService {
           feedDefinition.descriptionKey.map(Messages(_)(Lang(language.toString))),
           Some("self"),
           updated,
-          books)
+          books,
+          facets)
       })
+    }
+
+    def facetsForLanguages(currentLanguage: LanguageTag): Seq[Facet] = {
+      readService.listAvailableLanguages.map(lang => Facet(
+        href = s"${
+          BookApiProperties.CloudFrontOpds}${BookApiProperties.OpdsNewUrl.url
+          .replace(BookApiProperties.OpdsLanguageParam, lang.code)}",
+        title = s"${lang.name}",
+        group = "Languages",
+        isActive = LanguageTag(lang.code) == currentLanguage))
+    }
+
+    def facetsForReadingLevels(currentLanguage: LanguageTag, url: String): Seq[Facet] = {
+      readService.listAvailableLevelsForLanguage(Some(currentLanguage)).map(readingLevel =>
+        Facet(
+          href = s"${
+            BookApiProperties.CloudFrontOpds}${BookApiProperties.OpdsLevelUrl.url
+            .replace(BookApiProperties.OpdsLanguageParam, currentLanguage.toString)
+            .replace(BookApiProperties.OpdsLevelParam, readingLevel)}",
+          title = s"Level $readingLevel",
+          group = "Reading level",
+          isActive = url.endsWith(s"level$readingLevel.xml"))
+      )
     }
 
     def feedsForNavigation(language: LanguageTag): Seq[api.Feed] = {
@@ -65,7 +91,8 @@ trait FeedService {
           Messages(definition.titleKey),
           definition.descriptionKey.map(Messages(_)),
           Some("http://opds-spec.org/sort/new"),
-          justArrivedUpdated, Seq()))
+          justArrivedUpdated, Seq(),
+          Seq.empty))
 
 
       val levels: Seq[api.Feed] = readService.listAvailableLevelsForLanguage(Some(language))
@@ -83,7 +110,8 @@ trait FeedService {
               Messages(definition.titleKey, level),
               definition.descriptionKey.map(Messages(_)),
               None,
-              levelUpdated, Seq()))
+              levelUpdated, Seq(),
+              Seq.empty))
         })
 
       Seq(justArrived).flatten ++ levels

--- a/src/main/scala/no/gdl/bookapi/service/ReadService.scala
+++ b/src/main/scala/no/gdl/bookapi/service/ReadService.scala
@@ -37,6 +37,10 @@ trait ReadService {
       translationRepository.allAvailableLanguages().map(converterService.toApiLanguage).sortBy(_.name)
     }
 
+    def listAvailableLanguagesAsLanguageTags: Seq[LanguageTag] = {
+      translationRepository.allAvailableLanguages()
+    }
+
     def listAvailableLevelsForLanguage(lang: Option[LanguageTag] = None): Seq[String] =
       translationRepository.allAvailableLevels(lang)
 

--- a/src/test/scala/no/gdl/bookapi/TestData.scala
+++ b/src/test/scala/no/gdl/bookapi/TestData.scala
@@ -13,7 +13,6 @@ import java.util.UUID
 import io.digitallibrary.language.model.LanguageTag
 import no.gdl.bookapi.model._
 import no.gdl.bookapi.model.api.FeedCategory
-import no.gdl.bookapi.model.domain.{Category, Chapter, Contributor, EducationalAlignment}
 
 object TestData {
   val LanguageCodeNorwegian = "nob"
@@ -53,7 +52,15 @@ object TestData {
       Some(Level1), Some(ageRangeDefault), None, None, None, Some(today), Some(yesterday), today, Seq(category1, category2), None, api.Downloads(epub, pdf), Seq(), Seq(DefaultContributor), Seq(ChapterSummary1), supportsTranslation = true)
 
     val DefaultFeedDefinition = api.FeedDefinition(1, 1, "some-url", "some-uuid")
-    val DefaultFeed = api.Feed(DefaultFeedDefinition, "default title", Some("default description"), Some("default-rel"), yesterday, Seq())
+    val DefaultFacets = Seq(
+      api.Facet("https://opds.test.digitallibrary.io/eng/new.xml", "English", "Languages", isActive = true),
+      api.Facet("https://opds.test.digitallibrary.io/hin/new.xml", "Hindu", "Languages", isActive = false),
+      api.Facet("https://opds.test.digitallibrary.io/ben/new.xml", "Bengali", "Languages", isActive = false),
+      api.Facet("https://opds.test.digitallibrary.io/eng/level1.xml", "Level 1", "Reading level", isActive = false),
+      api.Facet("https://opds.test.digitallibrary.io/eng/level2.xml", "Level 2", "Reading level", isActive = true),
+      api.Facet("https://opds.test.digitallibrary.io/eng/level3.xml", "Level 3", "Reading level", isActive = false)
+    )
+    val DefaultFeed = api.Feed(DefaultFeedDefinition, "default title", Some("default description"), Some("default-rel"), yesterday, Seq(), DefaultFacets)
     val DefaultFeedEntry = api.FeedEntry(DefaultBook, Seq())
     val DefaultFeedCategory = FeedCategory("some-url", "some-title", 1)
   }

--- a/src/test/scala/no/gdl/bookapi/controller/OPDSControllerTest.scala
+++ b/src/test/scala/no/gdl/bookapi/controller/OPDSControllerTest.scala
@@ -65,6 +65,15 @@ class OPDSControllerTest extends UnitSuite with TestEnvironment {
         <title>{feed.title}</title>
         <updated>{feed.updated.atStartOfDay(ZoneId.systemDefault()).format(formatter)}</updated>
         <link href={feed.feedDefinition.url} rel="self"/>
+
+        <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/eng/new.xml" title="English" opds:facetGroup="Languages" opds:activeFacet="true"/>
+        <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/hin/new.xml" title="Hindu" opds:facetGroup="Languages" opds:activeFacet="false"/>
+        <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/ben/new.xml" title="Bengali" opds:facetGroup="Languages" opds:activeFacet="false"/>
+
+        <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/eng/level1.xml" title="Level 1" opds:facetGroup="Reading level" opds:activeFacet="false"/>
+        <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/eng/level2.xml" title="Level 2" opds:facetGroup="Reading level" opds:activeFacet="true"/>
+        <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/eng/level3.xml" title="Level 3" opds:facetGroup="Reading level" opds:activeFacet="false"/>
+
         <entry>
           <id>urn:uuid:{entry1.book.uuid}</id>
           <title>{entry1.book.title}</title>

--- a/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
+++ b/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
@@ -10,7 +10,7 @@ package no.gdl.bookapi.service
 import io.digitallibrary.language.model.LanguageTag
 import no.gdl.bookapi.BookApiProperties.{OpdsLanguageParam, OpdsLevelParam}
 import no.gdl.bookapi.TestData.{LanguageCodeAmharic, LanguageCodeEnglish, LanguageCodeNorwegian}
-import no.gdl.bookapi.model.api.{Facet, FeedEntry, Language}
+import no.gdl.bookapi.model.api.{Facet, FeedEntry}
 import no.gdl.bookapi.{BookApiProperties, TestData, TestEnvironment, UnitSuite}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -86,14 +86,10 @@ class FeedServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("that facetsForLanguage returns facets for languages") {
-    when(readService.listAvailableLanguages).thenReturn(Seq(
-      Language("eng", "English"),
-      Language("hin", "Hindu"),
-      Language("ben", "Bengali")))
-
+    when(readService.listAvailableLanguagesAsLanguageTags).thenReturn(Seq("eng", "hin", "ben").map(LanguageTag(_)))
     feedService.facetsForLanguages(LanguageTag("eng")) should equal (Seq(
       Facet("http://local.digitallibrary.io/book-api/opds/eng/new.xml", "English", "Languages", isActive = true),
-      Facet("http://local.digitallibrary.io/book-api/opds/hin/new.xml", "Hindu", "Languages", isActive = false),
+      Facet("http://local.digitallibrary.io/book-api/opds/hin/new.xml", "Hindi", "Languages", isActive = false),
       Facet("http://local.digitallibrary.io/book-api/opds/ben/new.xml", "Bengali", "Languages", isActive = false))
     )
   }

--- a/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
+++ b/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
@@ -10,7 +10,7 @@ package no.gdl.bookapi.service
 import io.digitallibrary.language.model.LanguageTag
 import no.gdl.bookapi.BookApiProperties.{OpdsLanguageParam, OpdsLevelParam}
 import no.gdl.bookapi.TestData.{LanguageCodeAmharic, LanguageCodeEnglish, LanguageCodeNorwegian}
-import no.gdl.bookapi.model.api.FeedEntry
+import no.gdl.bookapi.model.api.{Facet, FeedEntry, Language}
 import no.gdl.bookapi.{BookApiProperties, TestData, TestEnvironment, UnitSuite}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -83,5 +83,29 @@ class FeedServiceTest extends UnitSuite with TestEnvironment {
 
     withCategory.categories.size should be (1)
     withCategory.categories.head.url should equal (s"${BookApiProperties.CloudFrontOpds}/amh/level${feedEntry.book.readingLevel.get}.xml")
+  }
+
+  test("that facetsForLanguage returns facets for languages") {
+    when(readService.listAvailableLanguages).thenReturn(Seq(
+      Language("eng", "English"),
+      Language("hin", "Hindu"),
+      Language("ben", "Bengali")))
+
+    feedService.facetsForLanguages(LanguageTag("eng")) should equal (Seq(
+      Facet("http://local.digitallibrary.io/book-api/opds/eng/new.xml", "English", "Languages", isActive = true),
+      Facet("http://local.digitallibrary.io/book-api/opds/hin/new.xml", "Hindu", "Languages", isActive = false),
+      Facet("http://local.digitallibrary.io/book-api/opds/ben/new.xml", "Bengali", "Languages", isActive = false))
+    )
+  }
+
+  test("that facetsForReadingLevels returns facets for reading levels") {
+    val language = LanguageTag("eng")
+    when(readService.listAvailableLevelsForLanguage(Some(language))).thenReturn(Seq("1", "2", "3", "4"))
+    feedService.facetsForReadingLevels(language, "http://local.digitallibrary.io/book-api/opds/eng/level3.xml") should equal (Seq(
+      Facet("http://local.digitallibrary.io/book-api/opds/eng/level1.xml", "Level 1", "Reading level", isActive = false),
+      Facet("http://local.digitallibrary.io/book-api/opds/eng/level2.xml", "Level 2", "Reading level", isActive = false),
+      Facet("http://local.digitallibrary.io/book-api/opds/eng/level3.xml", "Level 3", "Reading level", isActive = true),
+      Facet("http://local.digitallibrary.io/book-api/opds/eng/level4.xml", "Level 4", "Reading level", isActive = false)
+    ))
   }
 }

--- a/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
+++ b/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
@@ -86,11 +86,12 @@ class FeedServiceTest extends UnitSuite with TestEnvironment {
   }
 
   test("that facetsForLanguage returns facets for languages") {
-    when(readService.listAvailableLanguagesAsLanguageTags).thenReturn(Seq("eng", "hin", "ben").map(LanguageTag(_)))
+    when(readService.listAvailableLanguagesAsLanguageTags).thenReturn(Seq("eng", "hin", "ben", "eng-latn-gb").map(LanguageTag(_)))
     feedService.facetsForLanguages(LanguageTag("eng")) should equal (Seq(
       Facet("http://local.digitallibrary.io/book-api/opds/eng/new.xml", "English", "Languages", isActive = true),
       Facet("http://local.digitallibrary.io/book-api/opds/hin/new.xml", "Hindi", "Languages", isActive = false),
-      Facet("http://local.digitallibrary.io/book-api/opds/ben/new.xml", "Bengali", "Languages", isActive = false))
+      Facet("http://local.digitallibrary.io/book-api/opds/ben/new.xml", "Bengali", "Languages", isActive = false),
+      Facet("http://local.digitallibrary.io/book-api/opds/eng-latn-gb/new.xml", "English (Latin, United Kingdom)", "Languages", isActive = false))
     )
   }
 


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#166

# TODO
- [ ] Consider removing `nav.xml` and using only 1 feed, defaulting to a default language and a default selection (e.g. similar to the selection of featured books, new arrivals and sample books from each reading level, as on the web page). Alternatively: Don't remove `nav.xml`, but do the default thing.