### PR TITLE
Issue#94 add paging to opds feeds

### DIFF
--- a/src/main/scala/no/gdl/bookapi/controller/OPDSController.scala
+++ b/src/main/scala/no/gdl/bookapi/controller/OPDSController.scala
@@ -14,6 +14,7 @@ import javax.servlet.http.HttpServletRequest
 import io.digitallibrary.language.model.LanguageTag
 import no.gdl.bookapi.BookApiProperties
 import no.gdl.bookapi.model.api.{Feed, FeedEntry}
+import no.gdl.bookapi.model.domain.Paging
 import no.gdl.bookapi.service.{ConverterService, FeedService, ReadService}
 import org.scalatra.NotFound
 
@@ -25,9 +26,19 @@ trait OPDSController {
   val dtf: DateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME
   implicit val localDateOrdering: Ordering[LocalDate] = Ordering.by(_.toEpochDay)
 
+  val defaultPageSize = 10
+  val maxPageSize = 100
+
   class OPDSController extends GdlController {
     before() {
       contentType = formats("xml")
+    }
+
+    def extractPageAndPageSize(): Paging = {
+      Paging(
+        page = intOrDefault("page", 1).max(1),
+        pageSize = intOrDefault("page-size", defaultPageSize).min(maxPageSize).max(1)
+      )
     }
 
     get(BookApiProperties.OpdsNavUrl.url) {
@@ -37,17 +48,21 @@ trait OPDSController {
     }
 
     get(BookApiProperties.OpdsRootUrl.url) {
-      acquisitionFeed(books = feedService.allEntries(LanguageTag(params("lang"))))
+      val paging = extractPageAndPageSize()
+      acquisitionFeed(books = feedService.allEntries(LanguageTag(params("lang")), paging), paging = paging)
     }
 
     get(BookApiProperties.OpdsNewUrl.url) {
-      acquisitionFeed(books = feedService.newEntries(LanguageTag(params("lang"))))
+      val paging = extractPageAndPageSize()
+      acquisitionFeed(books = feedService.newEntries(LanguageTag(params("lang"))), paging = paging)
     }
 
     get(BookApiProperties.OpdsLevelUrl.url) {
+      val paging = extractPageAndPageSize()
       acquisitionFeed(
         titleArgs = Seq(params("lev")),
-        books = feedService.entriesForLanguageAndLevel(LanguageTag(params("lang")), params("lev")))
+        books = feedService.entriesForLanguageAndLevel(LanguageTag(params("lang")), params("lev"), paging),
+        paging = paging)
     }
 
     private def navigationFeed(feedUpdated: Option[LocalDate], feeds: => Seq[Feed])(implicit request: HttpServletRequest) = {
@@ -61,10 +76,10 @@ trait OPDSController {
       }
     }
 
-    private def acquisitionFeed(feedUpdated: Option[LocalDate] = None, titleArgs: Seq[String] = Seq(), books: => Seq[FeedEntry])(implicit request: HttpServletRequest) = {
+    private def acquisitionFeed(feedUpdated: Option[LocalDate] = None, titleArgs: Seq[String] = Seq(), books: => Seq[FeedEntry], paging: Paging)(implicit request: HttpServletRequest) = {
       val lang = LanguageTag(params("lang"))
       feedService.feedForUrl(request.getRequestURI, lang, feedUpdated, titleArgs, books) match {
-        case Some(feed) => render(feed)
+        case Some(feed) => render(feed, paging)
         case None =>
           contentType = "text/plain"
           NotFound(body = s"No books available for language $lang.")
@@ -98,12 +113,13 @@ trait OPDSController {
       </feed>
     }
 
-    private[controller] def render(feed: Feed): Elem = {
+    private[controller] def render(feed: Feed, paging: Paging): Elem = {
       <feed xmlns="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/terms/" xmlns:opds="http://opds-spec.org/2010/catalog" xmlns:lrmi="http://purl.org/dcx/lrmi-terms/">
         <id>{feed.feedDefinition.uuid}</id>
         <title>{feed.title}</title>
         <updated>{feed.updated.atStartOfDay(ZoneId.systemDefault()).format(dtf)}</updated>
         <link href={feed.feedDefinition.url} rel="self"/>
+        <link href={s"${feed.feedDefinition.url}?page-size=${paging.pageSize}&page=${paging.page + 1}"} rel="next"/>
         {feed.facets.map(facet =>
           <link rel="http://opds-spec.org/facet" href={facet.href} title={facet.title} opds:facetGroup={facet.group} opds:activeFacet={facet.isActive.toString}/>)
         }

--- a/src/main/scala/no/gdl/bookapi/model/domain/Paging.scala
+++ b/src/main/scala/no/gdl/bookapi/model/domain/Paging.scala
@@ -1,0 +1,3 @@
+package no.gdl.bookapi.model.domain
+
+case class Paging(page: Int, pageSize: Int)

--- a/src/main/scala/no/gdl/bookapi/service/FeedService.scala
+++ b/src/main/scala/no/gdl/bookapi/service/FeedService.scala
@@ -20,6 +20,8 @@ import no.gdl.bookapi.model.api.{Facet, FeedCategory, FeedEntry}
 import no.gdl.bookapi.model.domain.Sort
 import no.gdl.bookapi.repository.{FeedRepository, TranslationRepository}
 
+import scala.util.Try
+
 trait FeedService {
   this: FeedRepository with TranslationRepository with ReadService with ConverterService =>
   val feedService: FeedService
@@ -55,7 +57,7 @@ trait FeedService {
     }
 
     def facetsForLanguages(currentLanguage: LanguageTag): Seq[Facet] = {
-      readService.listAvailableLanguagesAsLanguageTags.map(lang => Facet(
+      readService.listAvailableLanguagesAsLanguageTags.sortBy(_.toString).map(lang => Facet(
         href = s"${
           BookApiProperties.CloudFrontOpds}${BookApiProperties.OpdsNewUrl.url
           .replace(BookApiProperties.OpdsLanguageParam, lang.toString)}",
@@ -74,7 +76,8 @@ trait FeedService {
         group = group,
         isActive = url.endsWith("new.xml"))
         +:
-        readService.listAvailableLevelsForLanguage(Some(currentLanguage)).map(readingLevel =>
+        readService.listAvailableLevelsForLanguage(Some(currentLanguage))
+          .sortBy(level => Try(level.toInt).getOrElse(0)).map(readingLevel =>
           Facet(
             href = s"${
               BookApiProperties.CloudFrontOpds}${BookApiProperties.OpdsLevelUrl.url

--- a/src/test/scala/no/gdl/bookapi/TestData.scala
+++ b/src/test/scala/no/gdl/bookapi/TestData.scala
@@ -52,9 +52,9 @@ object TestData {
 
     val DefaultFeedDefinition = api.FeedDefinition(1, 1, "some-url", "some-uuid")
     val DefaultFacets = Seq(
+      api.Facet("https://opds.test.digitallibrary.io/ben/new.xml", "Bengali", "Languages", isActive = false),
       api.Facet("https://opds.test.digitallibrary.io/eng/new.xml", "English", "Languages", isActive = true),
       api.Facet("https://opds.test.digitallibrary.io/hin/new.xml", "Hindu", "Languages", isActive = false),
-      api.Facet("https://opds.test.digitallibrary.io/ben/new.xml", "Bengali", "Languages", isActive = false),
       api.Facet("https://opds.test.digitallibrary.io/eng/new.xml", "New arrivals", "Selection", isActive = false),
       api.Facet("https://opds.test.digitallibrary.io/eng/level1.xml", "Level 1", "Selection", isActive = false),
       api.Facet("https://opds.test.digitallibrary.io/eng/level2.xml", "Level 2", "Selection", isActive = true),

--- a/src/test/scala/no/gdl/bookapi/controller/OPDSControllerTest.scala
+++ b/src/test/scala/no/gdl/bookapi/controller/OPDSControllerTest.scala
@@ -11,6 +11,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 import no.gdl.bookapi.model.api.{Feed, FeedEntry}
+import no.gdl.bookapi.model.domain.Paging
 import no.gdl.bookapi.{TestData, TestEnvironment, UnitSuite}
 
 
@@ -65,7 +66,10 @@ class OPDSControllerTest extends UnitSuite with TestEnvironment {
         <title>{feed.title}</title>
         <updated>{feed.updated.atStartOfDay(ZoneId.systemDefault()).format(formatter)}</updated>
         <link href={feed.feedDefinition.url} rel="self"/>
-        <link href="some-url?page-size=100&amp;page=2" rel="next"/>
+        <link href="some-url?page-size=10&amp;page=1" rel="first"/>
+        <link href="some-url?page-size=10&amp;page=2" rel="previous"/>
+        <link href="some-url?page-size=10&amp;page=4" rel="next"/>
+        <link href="some-url?page-size=10&amp;page=10" rel="last"/>
 
         <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/ben/new.xml" title="Bengali" opds:facetGroup="Languages" opds:activeFacet="false"/>
         <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/eng/new.xml" title="English" opds:facetGroup="Languages" opds:activeFacet="true"/>
@@ -111,27 +115,55 @@ class OPDSControllerTest extends UnitSuite with TestEnvironment {
       </entry>
       </feed>
 
-    val generated = controller.render(feed, HasMore(currentPage = 1, currentPageSize = 100))
+    val generated = controller.render(feed, MoreInBothDirections(Paging(page = 3, pageSize = 10), lastPage = 10))
     val toCheck = generated.mkString.replaceAll("\\s", "")
     val expected = expectedXml.mkString.replaceAll("\\s", "")
 
     toCheck should equal (expected)
   }
 
-  test("that next link is present and pointing to the next page if there is more content to show") {
+  test("that only first, next and last links are present and correct if there is more content ahead") {
     val entry1: FeedEntry = TestData.Api.DefaultFeedEntry
     val entry2: FeedEntry = TestData.Api.DefaultFeedEntry.copy(categories = Seq(TestData.Api.DefaultFeedCategory))
     val feed = TestData.Api.DefaultFeed.copy(content = Seq(entry1, entry2))
-    val generated = controller.render(feed, HasMore(currentPage = 2, currentPageSize = 100))
+    val generated = controller.render(feed, MoreAhead(Paging(page = 2, pageSize = 100), lastPage = 11))
+    generated.mkString.contains("rel=\"previous\"") should be (false)
+    generated.mkString.contains("<link href=\"some-url?page-size=100&amp;page=1\" rel=\"first\"/>") should be (true)
     generated.mkString.contains("<link href=\"some-url?page-size=100&amp;page=3\" rel=\"next\"/>") should be (true)
+    generated.mkString.contains("<link href=\"some-url?page-size=100&amp;page=11\" rel=\"last\"/>") should be (true)
   }
 
-  test("that next link is not present when there is no more content to show") {
+  test("that only first and previous links are present and correct if there is more content before") {
     val entry1: FeedEntry = TestData.Api.DefaultFeedEntry
     val entry2: FeedEntry = TestData.Api.DefaultFeedEntry.copy(categories = Seq(TestData.Api.DefaultFeedCategory))
     val feed = TestData.Api.DefaultFeed.copy(content = Seq(entry1, entry2))
-    val generated = controller.render(feed, NothingMore)
-    generated.mkString.contains("<link href=\"some-url?page-size") should be (false)
+    val generated = controller.render(feed, MoreBefore(Paging(page = 3, pageSize = 100)))
+    generated.mkString.contains("rel=\"next\"") should be (false)
+    generated.mkString.contains("rel=\"last\"") should be (false)
+    generated.mkString.contains("<link href=\"some-url?page-size=100&amp;page=1\" rel=\"first\"/>") should be (true)
+    generated.mkString.contains("<link href=\"some-url?page-size=100&amp;page=2\" rel=\"previous\"/>") should be (true)
+  }
+
+  test("that first, previous, next and last links are present and correct if there is more content in both directions") {
+    val entry1: FeedEntry = TestData.Api.DefaultFeedEntry
+    val entry2: FeedEntry = TestData.Api.DefaultFeedEntry.copy(categories = Seq(TestData.Api.DefaultFeedCategory))
+    val feed = TestData.Api.DefaultFeed.copy(content = Seq(entry1, entry2))
+    val generated = controller.render(feed, MoreInBothDirections(Paging(page = 3, pageSize = 100), lastPage = 15))
+    generated.mkString.contains("<link href=\"some-url?page-size=100&amp;page=1\" rel=\"first\"/>") should be (true)
+    generated.mkString.contains("<link href=\"some-url?page-size=100&amp;page=2\" rel=\"previous\"/>") should be (true)
+    generated.mkString.contains("<link href=\"some-url?page-size=100&amp;page=4\" rel=\"next\"/>") should be (true)
+    generated.mkString.contains("<link href=\"some-url?page-size=100&amp;page=15\" rel=\"last\"/>") should be (true)
+  }
+
+  test("that only previous and next links are present when there is only 1 page to show") {
+    val entry1: FeedEntry = TestData.Api.DefaultFeedEntry
+    val entry2: FeedEntry = TestData.Api.DefaultFeedEntry.copy(categories = Seq(TestData.Api.DefaultFeedCategory))
+    val feed = TestData.Api.DefaultFeed.copy(content = Seq(entry1, entry2))
+    val generated = controller.render(feed, OnlyOnePage(Paging(page = 1, pageSize = 10)))
+    generated.mkString.contains("rel=\"previous\"") should be (false)
+    generated.mkString.contains("rel=\"next\"") should be (false)
+    generated.mkString.contains("<link href=\"some-url?page-size=10&amp;page=1\" rel=\"first\"/>") should be (true)
+    generated.mkString.contains("<link href=\"some-url?page-size=10&amp;page=1\" rel=\"last\"/>") should be (true)
   }
 
 

--- a/src/test/scala/no/gdl/bookapi/controller/OPDSControllerTest.scala
+++ b/src/test/scala/no/gdl/bookapi/controller/OPDSControllerTest.scala
@@ -11,6 +11,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 import no.gdl.bookapi.model.api.{Feed, FeedEntry}
+import no.gdl.bookapi.model.domain.Paging
 import no.gdl.bookapi.{TestData, TestEnvironment, UnitSuite}
 
 
@@ -65,6 +66,7 @@ class OPDSControllerTest extends UnitSuite with TestEnvironment {
         <title>{feed.title}</title>
         <updated>{feed.updated.atStartOfDay(ZoneId.systemDefault()).format(formatter)}</updated>
         <link href={feed.feedDefinition.url} rel="self"/>
+        <link href="some-url?page-size=100&amp;page=2" rel="next"/>
 
         <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/ben/new.xml" title="Bengali" opds:facetGroup="Languages" opds:activeFacet="false"/>
         <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/eng/new.xml" title="English" opds:facetGroup="Languages" opds:activeFacet="true"/>
@@ -110,7 +112,7 @@ class OPDSControllerTest extends UnitSuite with TestEnvironment {
       </entry>
       </feed>
 
-    val generated = controller.render(feed)
+    val generated = controller.render(feed, Paging(page = 1, pageSize = 100))
     val toCheck = generated.mkString.replaceAll("\\s", "")
     val expected = expectedXml.mkString.replaceAll("\\s", "")
 

--- a/src/test/scala/no/gdl/bookapi/controller/OPDSControllerTest.scala
+++ b/src/test/scala/no/gdl/bookapi/controller/OPDSControllerTest.scala
@@ -66,9 +66,9 @@ class OPDSControllerTest extends UnitSuite with TestEnvironment {
         <updated>{feed.updated.atStartOfDay(ZoneId.systemDefault()).format(formatter)}</updated>
         <link href={feed.feedDefinition.url} rel="self"/>
 
+        <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/ben/new.xml" title="Bengali" opds:facetGroup="Languages" opds:activeFacet="false"/>
         <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/eng/new.xml" title="English" opds:facetGroup="Languages" opds:activeFacet="true"/>
         <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/hin/new.xml" title="Hindu" opds:facetGroup="Languages" opds:activeFacet="false"/>
-        <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/ben/new.xml" title="Bengali" opds:facetGroup="Languages" opds:activeFacet="false"/>
 
         <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/eng/new.xml" title="New arrivals" opds:facetGroup="Selection" opds:activeFacet="false"/>
         <link rel="http://opds-spec.org/facet" href="https://opds.test.digitallibrary.io/eng/level1.xml" title="Level 1" opds:facetGroup="Selection" opds:activeFacet="false"/>

--- a/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
+++ b/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
@@ -85,19 +85,19 @@ class FeedServiceTest extends UnitSuite with TestEnvironment {
     withCategory.categories.head.url should equal (s"${BookApiProperties.CloudFrontOpds}/amh/level${feedEntry.book.readingLevel.get}.xml")
   }
 
-  test("that facetsForLanguage returns facets for languages") {
+  test("that facetsForLanguage returns facets for languages, with languages alphabetically sorted") {
     when(readService.listAvailableLanguagesAsLanguageTags).thenReturn(Seq("eng", "hin", "ben", "eng-latn-gb").map(LanguageTag(_)))
     feedService.facetsForLanguages(LanguageTag("eng")) should equal (Seq(
-      Facet("http://local.digitallibrary.io/book-api/opds/eng/new.xml", "English", "Languages", isActive = true),
-      Facet("http://local.digitallibrary.io/book-api/opds/hin/new.xml", "Hindi", "Languages", isActive = false),
       Facet("http://local.digitallibrary.io/book-api/opds/ben/new.xml", "Bengali", "Languages", isActive = false),
-      Facet("http://local.digitallibrary.io/book-api/opds/eng-latn-gb/new.xml", "English (Latin, United Kingdom)", "Languages", isActive = false))
+      Facet("http://local.digitallibrary.io/book-api/opds/eng/new.xml", "English", "Languages", isActive = true),
+      Facet("http://local.digitallibrary.io/book-api/opds/eng-latn-gb/new.xml", "English (Latin, United Kingdom)", "Languages", isActive = false),
+      Facet("http://local.digitallibrary.io/book-api/opds/hin/new.xml", "Hindi", "Languages", isActive = false))
     )
   }
 
-  test("that facetsForSelections returns facets for reading levels") {
+  test("that facetsForSelections returns facets for reading levels, with reading levels numerically sorted and new arrivals at the top") {
     val language = LanguageTag("eng")
-    when(readService.listAvailableLevelsForLanguage(Some(language))).thenReturn(Seq("1", "2", "3", "4"))
+    when(readService.listAvailableLevelsForLanguage(Some(language))).thenReturn(Seq("4", "1", "3", "2"))
     feedService.facetsForSelections(language, "http://local.digitallibrary.io/book-api/opds/eng/level3.xml") should equal (Seq(
       Facet("http://local.digitallibrary.io/book-api/opds/eng/new.xml", "New arrivals", "Selection", isActive = false),
       Facet("http://local.digitallibrary.io/book-api/opds/eng/level1.xml", "Level 1", "Selection", isActive = false),

--- a/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
+++ b/src/test/scala/no/gdl/bookapi/service/FeedServiceTest.scala
@@ -10,7 +10,8 @@ package no.gdl.bookapi.service
 import io.digitallibrary.language.model.LanguageTag
 import no.gdl.bookapi.BookApiProperties.{OpdsLanguageParam, OpdsLevelParam}
 import no.gdl.bookapi.TestData.{LanguageCodeAmharic, LanguageCodeEnglish, LanguageCodeNorwegian}
-import no.gdl.bookapi.model.api.{Facet, FeedEntry}
+import no.gdl.bookapi.model.api.{Facet, FeedEntry, SearchResult}
+import no.gdl.bookapi.model.domain.Paging
 import no.gdl.bookapi.{BookApiProperties, TestData, TestEnvironment, UnitSuite}
 import org.mockito.Matchers._
 import org.mockito.Mockito._
@@ -106,4 +107,29 @@ class FeedServiceTest extends UnitSuite with TestEnvironment {
       Facet("http://local.digitallibrary.io/book-api/opds/eng/level4.xml", "Level 4", "Selection", isActive = false)
     ))
   }
+
+  test("that searchResultToPagingStatus returns correct status when there's more content ahead") {
+    val searchResult = mock[SearchResult]
+    when(searchResult.totalCount).thenReturn(130)
+    feedService.searchResultToPagingStatus(searchResult, Paging(1, 25)) should equal (MoreAhead(Paging(1, 25), lastPage = 6))
+  }
+
+  test("that searchResultToPagingStatus returns correct status when there's more content before") {
+    val searchResult = mock[SearchResult]
+    when(searchResult.totalCount).thenReturn(50)
+    feedService.searchResultToPagingStatus(searchResult, Paging(2, 25)) should equal (MoreBefore(Paging(2, 25)))
+  }
+
+  test("that searchResultToPagingStatus returns correct status when there's more content in both directions") {
+    val searchResult = mock[SearchResult]
+    when(searchResult.totalCount).thenReturn(120)
+    feedService.searchResultToPagingStatus(searchResult, Paging(3, 25)) should equal (MoreInBothDirections(Paging(3, 25), lastPage = 5))
+  }
+
+  test("that searchResultToPagingStatus returns correct status when there's only one page of content") {
+    val searchResult = mock[SearchResult]
+    when(searchResult.totalCount).thenReturn(23)
+    feedService.searchResultToPagingStatus(searchResult, Paging(1, 25)) should equal (OnlyOnePage(Paging(1, 25)))
+  }
+
 }


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#94

* Added paging, which includes a next-link in the feeds.
* Sorted facets, so they show up in a predictable order.

Possible adjustments to consider:
- [x] Is it ok to always have a `next`-link even if there is no more content in the next page?
- [x] Is 10 an ok default page size value?
- [x] Should maxPageSize be larger than 100?
- [x] Do we need other link types as well? We can add `previous`, `first` and `last`. I don't think we need them.

(note: typo in issue number in branch name)