### PR TITLE
#94: Count total rows before limiting, in the same query

### DIFF
--- a/src/main/scala/no/gdl/bookapi/repository/TranslationRepository.scala
+++ b/src/main/scala/no/gdl/bookapi/repository/TranslationRepository.scala
@@ -19,6 +19,8 @@ trait TranslationRepository {
   this: ContributorRepository =>
   val translationRepository: TranslationRepository
 
+  val countAllBeforeLimiting = sqls"count(*) over ()"
+
   class TranslationRepository {
     private val (t, ch, ea, ctb, p, cat) = (
       Translation.syntax,
@@ -51,30 +53,23 @@ trait TranslationRepository {
       val limit = pageSize.max(1)
       val offset = (page.max(1) - 1) * pageSize
 
-      val results = select(t.result.bookId)
+      val result =
+        select(countAllBeforeLimiting, t.result.bookId)
         .from(Translation as t)
         .where.eq(t.language, language.toString)
         .append(getSorting(sortDef))
         .limit(limit).offset(offset)
         .toSQL
-        .map(_.long(1)).list().apply()
+        .map(row => (row.long(1), row.long(2))).list().apply()
 
-      SearchResult[Long](results.length, page, pageSize, language, results)
+      SearchResult[Long](result.map(_._1).headOption.getOrElse(0), page, pageSize, language, result.map(_._2))
     }
 
     def bookIdsWithLanguageAndLevel(language: LanguageTag, readingLevel: Option[String], pageSize: Int, page: Int, sortDef: Sort.Value)(implicit session: DBSession = ReadOnlyAutoSession): SearchResult[Long] = {
       val limit = pageSize.max(1)
       val offset = (page.max(1) - 1) * pageSize
 
-      val num_matching = select(sqls.count)
-        .from(Translation as t)
-        .where
-        .eq(t.language, language.toString)
-        .and(
-          sqls.toAndConditionOpt(readingLevel.map(l => sqls.eq(t.readingLevel, l))))
-        .toSQL.map(_.long(1)).single().apply()
-
-      val results = select(t.result.bookId)
+      val result = select(countAllBeforeLimiting, t.result.bookId)
         .from(Translation as t)
         .where
         .eq(t.language, language.toString)
@@ -82,9 +77,9 @@ trait TranslationRepository {
           sqls.toAndConditionOpt(readingLevel.map(l => sqls.eq(t.readingLevel, l))))
         .append(getSorting(sortDef))
         .limit(limit).offset(offset).toSQL
-        .map(_.long(1)).list().apply()
+        .map(row => (row.long(1), row.long(2))).list().apply()
 
-      SearchResult[Long](num_matching.getOrElse(0), page, pageSize, language, results)
+      SearchResult[Long](result.map(_._1).headOption.getOrElse(0), page, pageSize, language, result.map(_._2))
     }
 
     def forBookIdAndLanguage(bookId: Long, language: LanguageTag)(implicit session: DBSession = ReadOnlyAutoSession): Option[Translation] = {

--- a/src/test/scala/no/gdl/bookapi/repository/TranslationRepositoryTest.scala
+++ b/src/test/scala/no/gdl/bookapi/repository/TranslationRepositoryTest.scala
@@ -60,6 +60,25 @@ class TranslationRepositoryTest extends IntegrationSuite with TestEnvironment wi
     }
   }
 
+  test("that bookIdsWithLanguage gives correct totalCount when pageSize is less than number of books in database") {
+    withRollback { implicit session =>
+      val book1 = addBookDef()
+      val book2 = addBookDef()
+      val book3 = addBookDef()
+      val book4 = addBookDef()
+
+      addTranslationDef("ext1", "Title 1 - eng", book1.id.get, LanguageTag("eng"))
+      addTranslationDef("ext2", "Title 1 - nob", book1.id.get, LanguageTag("nob"))
+      addTranslationDef("ext3", "Title 2 - eng", book2.id.get, LanguageTag("eng"))
+      addTranslationDef("ext4", "Title 2 - nob", book2.id.get, LanguageTag("nob"))
+      addTranslationDef("ext6", "Title 3 - nob", book3.id.get, LanguageTag("nob"))
+      addTranslationDef("ext8", "Title 4 - nob", book4.id.get, LanguageTag("nob"))
+
+      val searchResult = translationRepository.bookIdsWithLanguage(LanguageTag("nob"), 3, 1, Sort.ByIdAsc)
+      searchResult.totalCount should equal(4)
+    }
+  }
+
   test("that languagesFor returns all languages for the given book") {
     withRollback { implicit session =>
       val book1 = addBookDef()
@@ -102,6 +121,23 @@ class TranslationRepositoryTest extends IntegrationSuite with TestEnvironment wi
 
       val ids = translationRepository.bookIdsWithLanguageAndLevel(LanguageTag("xho"), Some("2"), 10, 1, Sort.ByIdAsc)
       ids.results should equal (Seq(book1.id.get, book2.id.get))
+    }
+  }
+
+  test("that bookIdsWithLanguageAndLevel gives correct totalCount when pageSize is less than number of books in database") {
+    withRollback { implicit session =>
+      val book1 = addBookDef()
+      val book2 = addBookDef()
+      val book3 = addBookDef()
+      val book4 = addBookDef()
+
+      addTranslationDef("ext1", "title 1", book1.id.get, LanguageTag("xho"), Some("2"))
+      addTranslationDef("ext2", "title 2", book2.id.get, LanguageTag("xho"), Some("2"))
+      addTranslationDef("ext3", "title 3", book3.id.get, LanguageTag("xho"), Some("1"))
+      addTranslationDef("ext4", "title 4", book4.id.get, LanguageTag("xho"), Some("2"))
+
+      val ids = translationRepository.bookIdsWithLanguageAndLevel(LanguageTag("xho"), Some("2"), 1, 1, Sort.ByIdAsc)
+      ids.totalCount should equal (3)
     }
   }
 


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#94