### PR TITLE
#293: Changed to use LanguageTag as key in fontMap

### DIFF
--- a/src/main/scala/io/digitallibrary/bookapi/service/PdfService.scala
+++ b/src/main/scala/io/digitallibrary/bookapi/service/PdfService.scala
@@ -58,13 +58,13 @@ trait PdfService {
       "tamil" -> FontDefinition("/NotoSansTamil-Regular.ttf", "Noto Sans Tamil")
     )
     val fontDefinitions = Map(
-      "amh" -> fonts("ethiopic"),
-      "mar" -> fonts("devangari"),
-      "hin" -> fonts("devangari"),
-      "ben" -> fonts("bengali"),
-      "nep" -> fonts("devangari"),
-      "khm" -> fonts("khmer"),
-      "tam" -> fonts("tamil")
+      LanguageTag("amh") -> fonts("ethiopic"),
+      LanguageTag("mar") -> fonts("devangari"),
+      LanguageTag("hin") -> fonts("devangari"),
+      LanguageTag("ben") -> fonts("bengali"),
+      LanguageTag("nep") -> fonts("devangari"),
+      LanguageTag("khm") -> fonts("khmer"),
+      LanguageTag("tam") -> fonts("tamil")
     )
 
     def getPdf(language: LanguageTag, uuid: String): Option[PdfStream] = {
@@ -86,7 +86,7 @@ trait PdfService {
         val publisher = bookRepository.withId(translation.bookId).map(_.publisher.name)
 
         val chapters = readService.chaptersForIdAndLanguage(translation.bookId, language).flatMap(ch => readService.chapterForBookWithLanguageAndId(translation.bookId, language, ch.id))
-        val fonts = fontDefinitions.get(language.toString).toSeq :+ DefaultFont
+        val fonts = fontDefinitions.get(language).toSeq :+ DefaultFont
 
         val bookAsHtml =
           s"""

--- a/src/test/scala/io/digitallibrary/bookapi/service/PdfServiceTest.scala
+++ b/src/test/scala/io/digitallibrary/bookapi/service/PdfServiceTest.scala
@@ -56,4 +56,13 @@ class PdfServiceTest extends UnitSuite with TestEnvironment {
     val pdf = pdfService.getPdf(LanguageTag("eng"), uuid)
     pdf.get.fileName should be ("Default translation title.pdf")
   }
+
+  test("that correct font is recognized") {
+    pdfService.fontDefinitions.get(LanguageTag("amh")) should equal (Some(pdfService.FontDefinition("/NotoSansEthiopic.ttf", "Noto Sans Ethiopic")))
+    pdfService.fontDefinitions.get(LanguageTag("am")) should equal (Some(pdfService.FontDefinition("/NotoSansEthiopic.ttf", "Noto Sans Ethiopic")))
+    pdfService.fontDefinitions.get(LanguageTag("km")) should equal (Some(pdfService.FontDefinition("/NotoSansKhmer-Regular.ttf", "Noto Sans Khmer")))
+    pdfService.fontDefinitions.get(LanguageTag("khm")) should equal (Some(pdfService.FontDefinition("/NotoSansKhmer-Regular.ttf", "Noto Sans Khmer")))
+    pdfService.fontDefinitions.get(LanguageTag("nob")) should be (None)
+
+  }
 }


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#293