### PR TITLE
#278: Use v1 in all OPDS urls, including CloudFront

### DIFF
--- a/src/main/scala/io/digitallibrary/bookapi/BookApiProperties.scala
+++ b/src/main/scala/io/digitallibrary/bookapi/BookApiProperties.scala
@@ -43,15 +43,15 @@ object BookApiProperties extends LazyLogging {
 
   val DefaultLanguage = "eng"
 
-  val OpdsPath = "/book-api/opds/v1"
+  val OpdsPath = "/book-api/opds"
   val OpdsLanguageParam = ":lang"
   val OpdsCategoryParam = ":category"
   val OpdsLevelParam = ":lev"
 
-  val OpdsRootDefaultLanguageUrl = s"/root.xml"
-  val OpdsRootUrl = s"/$OpdsLanguageParam/root.xml"
-  val OpdsCategoryUrl = s"/$OpdsLanguageParam/category/$OpdsCategoryParam/root.xml"
-  val OpdsCategoryAndLevelUrl = s"/$OpdsLanguageParam/category/$OpdsCategoryParam/level/$OpdsLevelParam.xml"
+  val OpdsRootDefaultLanguageUrl = s"/v1/root.xml"
+  val OpdsRootUrl = s"/v1/$OpdsLanguageParam/root.xml"
+  val OpdsCategoryUrl = s"/v1/$OpdsLanguageParam/category/$OpdsCategoryParam/root.xml"
+  val OpdsCategoryAndLevelUrl = s"/v1/$OpdsLanguageParam/category/$OpdsCategoryParam/level/$OpdsLevelParam.xml"
 
   val DownloadPath = "/book-api/download"
   val Books = "books"

--- a/src/test/scala/io/digitallibrary/bookapi/controller/OPDSControllerTest.scala
+++ b/src/test/scala/io/digitallibrary/bookapi/controller/OPDSControllerTest.scala
@@ -164,7 +164,7 @@ class OPDSControllerTest extends UnitSuite with TestEnvironment with ScalatraFun
   }
 
   test("that /root.xml defaults to English root feed with default paging") {
-    get("/root.xml") {
+    get("/v1/root.xml") {
       verify(feedService).allEntries(LanguageTag("eng"), Paging(page = 1, pageSize = 15))
     }
   }

--- a/src/test/scala/io/digitallibrary/bookapi/service/FeedServiceTest.scala
+++ b/src/test/scala/io/digitallibrary/bookapi/service/FeedServiceTest.scala
@@ -49,7 +49,7 @@ class FeedServiceTest extends UnitSuite with TestEnvironment {
         .replace(OpdsCategoryParam, "cat1")
         .replace(OpdsLanguageParam, LanguageCodeEnglish)}")
 
-    calculatedFeedUrls.map(_.url).sorted should equal (Seq("/en/category/cat1/level/1.xml", "/en/category/cat1/root.xml", "/en/root.xml", "/root.xml").sorted)
+    calculatedFeedUrls.map(_.url).sorted should equal (Seq("/v1/en/category/cat1/level/1.xml", "/v1/en/category/cat1/root.xml", "/v1/en/root.xml", "/v1/root.xml").sorted)
   }
 
   test("that calculateFeedUrls calculates correct of feeds for multiple languages and levels") {
@@ -69,17 +69,17 @@ class FeedServiceTest extends UnitSuite with TestEnvironment {
     val calculatedFeedUrls = feedService.calculateFeeds
     val expectedFeeds =
       """
-        |/root.xml
-        |/en/root.xml
-        |/nb/root.xml
-        |/nb/category/library_books/root.xml
-        |/nb/category/classroom_books/root.xml
-        |/nb/category/library_books/level/1.xml
-        |/nb/category/library_books/level/2.xml
-        |/nb/category/classroom_books/level/decodable.xml
-        |/en/category/library_books/root.xml
-        |/en/category/library_books/level/1.xml
-        |/en/category/library_books/level/2.xml
+        |/v1/root.xml
+        |/v1/en/root.xml
+        |/v1/nb/root.xml
+        |/v1/nb/category/library_books/root.xml
+        |/v1/nb/category/classroom_books/root.xml
+        |/v1/nb/category/library_books/level/1.xml
+        |/v1/nb/category/library_books/level/2.xml
+        |/v1/nb/category/classroom_books/level/decodable.xml
+        |/v1/en/category/library_books/root.xml
+        |/v1/en/category/library_books/level/1.xml
+        |/v1/en/category/library_books/level/2.xml
       """
       .stripMargin.trim.split("\n").toSet
 


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#278