### PR TITLE
#389: Pass chapters in same object as translation + cleanup exceeding…

### DIFF
--- a/src/main/scala/io/digitallibrary/bookapi/model/api/internal/Internal.scala
+++ b/src/main/scala/io/digitallibrary/bookapi/model/api/internal/Internal.scala
@@ -60,7 +60,8 @@ case class NewTranslation(externalId: Option[String],
                           pageOrientation: Option[String],
                           contributors: Seq[NewContributor],
                           categories: Seq[NewCategory],
-                          educationalAlignment: Option[NewEducationalAlignment])
+                          educationalAlignment: Option[NewEducationalAlignment],
+                          chapters: Seq[NewChapter])
 
 case class NewChapter(seqNo: Int,
                       title: Option[String],

--- a/src/main/scala/io/digitallibrary/bookapi/service/ValidationService.scala
+++ b/src/main/scala/io/digitallibrary/bookapi/service/ValidationService.scala
@@ -11,7 +11,7 @@ import com.typesafe.scalalogging.LazyLogging
 import io.digitallibrary.bookapi.model._
 import io.digitallibrary.bookapi.model.api.internal.NewTranslation
 import io.digitallibrary.bookapi.model.api.{ValidationException, ValidationMessage}
-import io.digitallibrary.bookapi.model.domain.{ChapterType, ContributorType}
+import io.digitallibrary.bookapi.model.domain.ContributorType
 import org.apache.commons.validator.routines.UrlValidator
 import org.jsoup.Jsoup
 import org.jsoup.safety.Whitelist


### PR DESCRIPTION
GlobalDigitalLibraryio/issues#389

Dette er ikke en 100% løsning, da vi egentlig ønsker å slå sammen load (fra annet miljø) og import (ny/oppdatert bok), men det er en ok første løsning på problemet med at overflødige eksisterende kapitler ikke blir fjernet, og det gjør det raskere å poste en ny/oppdatert bok, da det ikke krever en POST per kapittel lenger.